### PR TITLE
added .flake8 file to ignore E501 error message

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,2 @@
+[flake8]
+ignore = E501


### PR DESCRIPTION
According to the flake8 [docs](https://flake8.pycqa.org/en/3.1.1/user/configuration.html#configuration), I can add a `.flake8` file in the top level of my project and can add in what error messages I want it to ignore.  In this case, I would like it to ignore the E501 error which says my line is too long.  This will also hopefully fix where CI is flagging it, as well.