### PR TITLE
player cannot choose a spot that is already taken

### DIFF
--- a/src/game.py
+++ b/src/game.py
@@ -44,6 +44,13 @@ class Game:
         self.place_mark_on_board(position_choice, self.board, self.play_count)
         print(self.initialize_board())
 
+    def is_spot_taken(self, user_input, board, play_count):
+        input_index = user_input - 1
+        if board[input_index] not in board:
+            self.place_mark_on_board(user_input, board, play_count)
+        else:
+            return "Spot is taken - choose another spot"
+
     def run(self):
         print(self.get_welcome_message())
         print(self.initialize_board())

--- a/test/test_game.py
+++ b/test/test_game.py
@@ -90,6 +90,26 @@ class TestGame(unittest.TestCase):
         game.place_mark_on_board(user_input, board, play_count)
         self.assertEqual(board[2], next_player)
 
+    def test_player_cant_mark_board_when_spot_is_taken(self):
+        game = Game()
+        board = ["1", "2", "X", "4", "5", "6", "7", "8", "9"]
+        user_input = 3
+        play_count = 1
+        error_prompt = game.is_spot_taken(user_input, board, play_count)
+        self.assertEqual("Spot is taken - choose another spot", error_prompt)
 
-# test - when X replaces 1, board is reprinted with X in spot 1
-# test - when X replaces 1, it is O's turn and repeat
+    def test_player_cant_mark_board_when_spot_is_taken_2(self):
+        game = Game()
+        board = ["1", "2", "X", "4", "5", "6", "7", "O", "9"]
+        user_input = 8
+        play_count = 2
+        error_prompt = game.is_spot_taken(user_input, board, play_count)
+        self.assertEqual("Spot is taken - choose another spot", error_prompt)
+
+    def test_player_cant_mark_board_when_spot_is_taken_3(self):
+        game = Game()
+        board = ["1", "2", "X", "4", "5", "6", "7", "O", "X"]
+        user_input = 9
+        play_count = 3
+        error_prompt = game.is_spot_taken(user_input, board, play_count)
+        self.assertEqual("Spot is taken - choose another spot", error_prompt)


### PR DESCRIPTION
Added in method `is_spot_taken` to check whether `player_one` or `player_two` mark is already in the spot they chose.  If so, an error message will return to let them know to pick another spot.