### PR TITLE
Single comp player

### DIFF
--- a/src/computer_player.py
+++ b/src/computer_player.py
@@ -2,5 +2,9 @@ import random
 
 
 class ComputerPlayer:
+    def __init__(self):
+        self.player_one_mark = "X"
+        self.player_two_mark = "O"
+
     def computer_input(self):
         return random.randint(1, 9)

--- a/src/computer_player.py
+++ b/src/computer_player.py
@@ -3,27 +3,11 @@ from src.validator import Validator as validator
 
 
 class ComputerPlayer:
-    def __init__(self):
-        self.player_one_mark = "X"
-        self.player_two_mark = "O"
+    def __init__(self, mark):
+        self.mark = mark
 
-    def computer_input(self):
-        return random.randint(1, 9)
-
-    # def valid_computer_move(self, move, board):
-    #     if not validator.spot_is_available(self, board, move):
-    #         return self.valid_computer_move(self.computer_input(), board)
-    #     return move
-
-    def valid_computer_move(self, move, board):
-        if validator.spot_is_available(self, board, move):
-            return True
-        else:
-            return False
-
-    # change to get_move
-    def get_computer_move(self, move, board):
-        if not self.valid_computer_move(move, board):
-            move = self.computer_input()
-            return self.get_computer_move(move, board)
+    def get_move(self, board):
+        move = random.randint(1, 9)
+        if not validator.spot_is_available(self, board, move):
+            return self.get_move(board)
         return move

--- a/src/computer_player.py
+++ b/src/computer_player.py
@@ -6,8 +6,8 @@ class ComputerPlayer:
     def __init__(self, mark):
         self.mark = mark
 
-    def get_move(self, board):
+    def get_move(self, board, message):
         move = random.randint(1, 9)
         if not validator.spot_is_available(self, board, move):
-            return self.get_move(board)
+            return self.get_move(board, message)
         return move

--- a/src/computer_player.py
+++ b/src/computer_player.py
@@ -1,4 +1,5 @@
 import random
+from src.validator import Validator as validator
 
 
 class ComputerPlayer:
@@ -8,3 +9,21 @@ class ComputerPlayer:
 
     def computer_input(self):
         return random.randint(1, 9)
+
+    # def valid_computer_move(self, move, board):
+    #     if not validator.spot_is_available(self, board, move):
+    #         return self.valid_computer_move(self.computer_input(), board)
+    #     return move
+
+    def valid_computer_move(self, move, board):
+        if validator.spot_is_available(self, board, move):
+            return True
+        else:
+            return False
+
+    # change to get_move
+    def get_computer_move(self, move, board):
+        if not self.valid_computer_move(move, board):
+            move = self.computer_input()
+            return self.get_computer_move(move, board)
+        return move

--- a/src/computer_player.py
+++ b/src/computer_player.py
@@ -1,0 +1,6 @@
+import random
+
+
+class ComputerPlayer:
+    def computer_input(self):
+        return random.randint(1, 9)

--- a/src/config.py
+++ b/src/config.py
@@ -1,6 +1,6 @@
 config = {
-    "player_one": "X",
-    "player_two": "O",
+    "player_one_mark": "X",
+    "player_two_mark": "O",
     "play_in_spanish": "2",
     "play_with_symbols": "2",
     "play_again": "Y",

--- a/src/config.py
+++ b/src/config.py
@@ -4,4 +4,6 @@ config = {
     "play_in_spanish": "2",
     "play_with_symbols": "2",
     "play_again": "Y",
+    "human_vs_human": "1",
+    "human_vs_comp": "2",
 }

--- a/src/config.py
+++ b/src/config.py
@@ -1,6 +1,4 @@
 config = {
-    "player_one_mark": "X",
-    "player_two_mark": "O",
     "play_in_spanish": "2",
     "play_with_symbols": "2",
     "play_again": "Y",

--- a/src/game.py
+++ b/src/game.py
@@ -1,5 +1,6 @@
 import random
 from src.board import Board
+from src.human_player import HumanPlayer
 from src.message import Message
 from src.rules import Rules
 from src.spanish_message import SpanishMessage
@@ -16,14 +17,15 @@ class Game:
         self.rules = Rules()
         self.validator = Validator()
         self.symbol = SymbolOptions()
+        self.human_player = HumanPlayer()
         self.computer_player = ComputerPlayer()
         self.ui = ui
         self.set_language(message)
         self.game_board = self.board.starter_board
         # self.player_one = config["player_one"]
         # self.player_two = config["player_two"]
-        self.player_one_mark = config["player_one_mark"]
-        self.player_two_mark = config["player_two_mark"]
+        self.player_one_mark = self.human_player.player_one_mark
+        self.player_two_mark = self.human_player.player_two_mark
         self.total_marks_on_board = 0
         self.playing = True
         self.play_against_computer = False

--- a/src/game.py
+++ b/src/game.py
@@ -1,3 +1,5 @@
+import random
+from traceback import print_tb
 from src.board import Board
 from src.message import Message
 from src.rules import Rules
@@ -22,6 +24,41 @@ class Game:
         self.total_marks_on_board = 0
         self.playing = True
 
+    def computer_input(self):
+        return random.randint(1, 9)
+
+    def valid_computer_move(self):
+        computer_move = self.computer_input()
+        valid_computer_move = self.validator.spot_is_available(
+            self.game_board, computer_move
+        )
+        while not valid_computer_move:
+            computer_move = self.computer_input()
+            valid_computer_move = self.validator.spot_is_available(
+                self.game_board, computer_move
+            )
+        return computer_move
+
+    def handle_computer_marks_board(self):
+        self.game_board = self.board.mark_board(
+            self.valid_computer_move(),
+            self.game_board,
+            self.get_current_player(self.total_marks_on_board),
+        )
+        self.total_marks_on_board = self.board.count_marks(
+            self.game_board, self.player_one, self.player_two
+        )
+
+    def take_turns_with_computer(self):
+        self.prompt_for_move(self.total_marks_on_board)
+        self.handle_mark_board()
+        self.ui.display_message("Computer took turn")
+        self.handle_computer_marks_board()
+        self.total_marks_on_board = self.board.count_marks(
+            self.game_board, self.player_one, self.player_two
+        )
+        self.get_formatted_board()
+
     def set_language(self, message):
         self.message = message
 
@@ -32,6 +69,9 @@ class Game:
             new_user_input = self.ui.get_user_input()
             return self.get_menu_choice(new_user_input, message)
         return user_input
+
+    # def set_players(self):
+    #     self.ui.display_message(self.message.choose_players())
 
     def change_language(self):
         self.ui.display_message(self.message.choose_language())
@@ -153,6 +193,7 @@ class Game:
                 self.ask_to_play_again()
             else:
                 self.take_turns()
+                # self.take_turns_with_computer()
 
     def run(self):
         self.ui.display_message(self.message.welcome_message())

--- a/src/game.py
+++ b/src/game.py
@@ -27,10 +27,8 @@ class Game:
         self.play_against_computer = False
 
     def valid_computer_move(self, move):
-        valid_computer_move = self.validator.spot_is_available(self.game_board, move)
-        if not valid_computer_move:
-            new_computer_move = self.computer_player.computer_input()
-            return self.valid_computer_move(new_computer_move)
+        if not self.validator.spot_is_available(self.game_board, move):
+            return self.valid_computer_move(self.computer_player.computer_input())
         return move
 
     def handle_computer_mark_board(self):

--- a/src/game.py
+++ b/src/game.py
@@ -17,15 +17,11 @@ class Game:
         self.rules = Rules()
         self.validator = Validator()
         self.symbol = SymbolOptions()
-        self.human_player = HumanPlayer()
-        self.computer_player = ComputerPlayer()
         self.ui = ui
         self.set_language(message)
         self.game_board = self.board.starter_board
-        # self.player_one = config["player_one"]
-        # self.player_two = config["player_two"]
-        self.player_one_mark = self.human_player.player_one_mark
-        self.player_two_mark = self.human_player.player_two_mark
+        self.player_one = HumanPlayer("X")
+        self.player_two = HumanPlayer("O")
         self.total_marks_on_board = 0
         self.playing = True
         self.play_against_computer = False
@@ -47,9 +43,9 @@ class Game:
             self.ui.get_user_input(), self.message.invalid_menu_input()
         )
         if user_input == config["human_vs_comp"]:
+            self.player_one = HumanPlayer("X")
+            self.player_two = ComputerPlayer("O")
             self.play_against_computer = True
-        if user_input == config["human_vs_human"]:
-            self.play_against_computer = False
 
     def change_language(self):
         self.ui.display_message(self.message.choose_language())
@@ -66,10 +62,10 @@ class Game:
         )
         if user_input == config["play_with_symbols"]:
             self.ui.display_message(self.message.display_symbols())
-            self.player_one_mark = self.set_player_symbol(
+            self.player_one.mark = self.set_player_symbol(
                 self.message.choose_symbol_player_one()
             )
-            self.player_two_mark = self.set_player_symbol(
+            self.player_two.mark = self.set_player_symbol(
                 self.message.choose_symbol_player_two()
             )
 
@@ -88,54 +84,24 @@ class Game:
 
     def get_current_player(self, total_marks_on_board):
         if total_marks_on_board % 2 == 0:
-            return self.player_one_mark
+            return self.player_one
         else:
-            return self.player_two_mark
+            return self.player_two
 
     def prompt_for_move(self, total_marks_on_board):
         current_player = self.get_current_player(total_marks_on_board)
         self.ui.display_message(self.message.prompt_for_move(current_player))
 
-    def handle_mark_board(self):
-        move = self.ui.get_user_input()
-        valid_move = self.validator.is_valid_move(self.game_board, move)
-        while not valid_move:
-            self.ui.display_message(self.message.invalid_board_input())
-            move = self.ui.get_user_input()
-            valid_move = self.validator.is_valid_move(self.game_board, move)
-        self.game_board = self.board.mark_board(
-            move,
-            self.game_board,
-            self.get_current_player(self.total_marks_on_board),
-        )
-        self.total_marks_on_board = self.board.count_marks(
-            self.game_board, self.player_one_mark, self.player_two_mark
-        )
-
-    def handle_computer_mark_board(self):
-        computer_move = self.computer_player.computer_input()
-        if not self.rules.is_winner(self.game_board):
-            self.game_board = self.board.mark_board(
-                self.computer_player.get_computer_move(computer_move, self.game_board),
-                self.game_board,
-                self.get_current_player(self.total_marks_on_board),
-            )
-            self.total_marks_on_board = self.board.count_marks(
-                self.game_board, self.player_one_mark, self.player_two_mark
-            )
-
     def new_game(self):
         self.total_marks_on_board = 0
         self.game_board = Board().starter_board
-        self.player_one_mark = self.human_player.player_one_mark
-        self.player_two_mark = self.human_player.player_two_mark
 
     def get_winning_mark(self, total_marks_on_board):
         player = self.get_current_player(total_marks_on_board)
-        if player == self.player_one_mark:
-            return self.player_two_mark
+        if player.mark == self.player_one.mark:
+            return self.player_two.mark
         else:
-            return self.player_one_mark
+            return self.player_one.mark
 
     def handle_winning_game(self):
         winner = self.get_winning_mark(self.total_marks_on_board)
@@ -144,29 +110,23 @@ class Game:
     def handle_draw(self):
         self.ui.display_message(self.message.game_over_message())
 
-    def take_turns_human_vs_human(self):
-        self.prompt_for_move(self.total_marks_on_board)
-        self.handle_mark_board()
-        self.total_marks_on_board = self.board.count_marks(
-            self.game_board, self.player_one_mark, self.player_two_mark
-        )
-        self.get_formatted_board()
-
-    def take_turns_comp_vs_human(self):
-        self.prompt_for_move(self.total_marks_on_board)
-        self.handle_mark_board()
-        self.ui.display_message(self.message.computer_took_turn())
-        self.handle_computer_mark_board()
-        self.total_marks_on_board = self.board.count_marks(
-            self.game_board, self.player_one_mark, self.player_two_mark
-        )
-        self.get_formatted_board()
+    def handle_mark_board(self, player, board):
+        move = player.get_move(board)
+        current_player = self.get_current_player(self.total_marks_on_board)
+        if not self.rules.is_winner(self.game_board):
+            self.game_board = self.board.mark_board(move, board, current_player.mark)
+            self.total_marks_on_board = self.board.count_marks(
+                board, self.player_one.mark, self.player_two.mark
+            )
 
     def take_turns(self):
-        if self.play_against_computer:
-            self.take_turns_comp_vs_human()
-        else:
-            self.take_turns_human_vs_human()
+        current_player = self.get_current_player(self.total_marks_on_board)
+        self.prompt_for_move(self.total_marks_on_board)
+        self.handle_mark_board(current_player, self.game_board)
+        self.total_marks_on_board = self.board.count_marks(
+            self.game_board, self.player_one.mark, self.player_two.mark
+        )
+        self.get_formatted_board()
 
     def repeat_game(self):
         self.new_game()
@@ -192,7 +152,7 @@ class Game:
                 self.ask_to_play_again()
             elif self.board.is_full(
                 self.board.count_marks(
-                    self.game_board, self.player_one_mark, self.player_two_mark
+                    self.game_board, self.player_one.mark, self.player_two.mark
                 ),
                 self.game_board,
             ):

--- a/src/game.py
+++ b/src/game.py
@@ -40,14 +40,15 @@ class Game:
         return computer_move
 
     def handle_computer_marks_board(self):
-        self.game_board = self.board.mark_board(
-            self.valid_computer_move(),
-            self.game_board,
-            self.get_current_player(self.total_marks_on_board),
-        )
-        self.total_marks_on_board = self.board.count_marks(
-            self.game_board, self.player_one, self.player_two
-        )
+        if not self.rules.is_winner(self.game_board):
+            self.game_board = self.board.mark_board(
+                self.valid_computer_move(),
+                self.game_board,
+                self.get_current_player(self.total_marks_on_board),
+            )
+            self.total_marks_on_board = self.board.count_marks(
+                self.game_board, self.player_one, self.player_two
+            )
 
     def take_turns_with_computer(self):
         self.prompt_for_move(self.total_marks_on_board)

--- a/src/game.py
+++ b/src/game.py
@@ -1,5 +1,6 @@
 import random
 from src.board import Board
+from src.human_player import HumanPlayer
 from src.message import Message
 from src.rules import Rules
 from src.spanish_message import SpanishMessage
@@ -17,6 +18,7 @@ class Game:
         self.validator = Validator()
         self.symbol = SymbolOptions()
         self.computer_player = ComputerPlayer()
+        self.human_player = HumanPlayer()
         self.ui = ui
         self.set_language(message)
         self.game_board = self.board.starter_board
@@ -26,22 +28,18 @@ class Game:
         self.playing = True
         self.play_against_computer = False
 
-    def valid_computer_move(self):
-        computer_move = self.computer_player.computer_input()
-        valid_computer_move = self.validator.spot_is_available(
-            self.game_board, computer_move
-        )
-        while not valid_computer_move:
-            computer_move = self.computer_player.computer_input()
-            valid_computer_move = self.validator.spot_is_available(
-                self.game_board, computer_move
-            )
-        return computer_move
+    def valid_computer_move(self, move):
+        valid_computer_move = self.validator.spot_is_available(self.game_board, move)
+        if not valid_computer_move:
+            new_computer_move = self.computer_player.computer_input()
+            return self.valid_computer_move(new_computer_move)
+        return move
 
     def handle_computer_mark_board(self):
+        computer_move = self.computer_player.computer_input()
         if not self.rules.is_winner(self.game_board):
             self.game_board = self.board.mark_board(
-                self.valid_computer_move(),
+                self.valid_computer_move(computer_move),
                 self.game_board,
                 self.get_current_player(self.total_marks_on_board),
             )

--- a/src/game.py
+++ b/src/game.py
@@ -111,7 +111,7 @@ class Game:
         self.ui.display_message(self.message.game_over_message())
 
     def handle_mark_board(self, player, board):
-        move = player.get_move(board, self.message.invalid_board_input())
+        move = player.get_move(board, self.message)
         current_player = self.get_current_player(self.total_marks_on_board)
         if not self.rules.is_winner(self.game_board):
             self.game_board = self.board.mark_board(move, board, current_player.mark)

--- a/src/game.py
+++ b/src/game.py
@@ -1,6 +1,5 @@
 import random
 from src.board import Board
-from src.human_player import HumanPlayer
 from src.message import Message
 from src.rules import Rules
 from src.spanish_message import SpanishMessage
@@ -18,7 +17,6 @@ class Game:
         self.validator = Validator()
         self.symbol = SymbolOptions()
         self.computer_player = ComputerPlayer()
-        self.human_player = HumanPlayer()
         self.ui = ui
         self.set_language(message)
         self.game_board = self.board.starter_board

--- a/src/game.py
+++ b/src/game.py
@@ -163,7 +163,7 @@ class Game:
     def take_turns_comp_vs_human(self):
         self.prompt_for_move(self.total_marks_on_board)
         self.handle_mark_board()
-        self.ui.display_message("Computer took turn")
+        self.ui.display_message(self.message.computer_took_turn())
         self.handle_computer_mark_board()
         self.total_marks_on_board = self.board.count_marks(
             self.game_board, self.player_one, self.player_two

--- a/src/game.py
+++ b/src/game.py
@@ -1,5 +1,4 @@
 import random
-from traceback import print_tb
 from src.board import Board
 from src.message import Message
 from src.rules import Rules
@@ -68,7 +67,7 @@ class Game:
         )
         if user_input == config["human_vs_comp"]:
             self.play_against_computer = True
-        else:
+        if user_input == config["human_vs_human"]:
             self.play_against_computer = False
 
     def change_language(self):

--- a/src/game.py
+++ b/src/game.py
@@ -116,7 +116,7 @@ class Game:
         computer_move = self.computer_player.computer_input()
         if not self.rules.is_winner(self.game_board):
             self.game_board = self.board.mark_board(
-                self.valid_computer_move(computer_move),
+                self.computer_player.get_computer_move(computer_move, self.game_board),
                 self.game_board,
                 self.get_current_player(self.total_marks_on_board),
             )
@@ -124,16 +124,11 @@ class Game:
                 self.game_board, self.player_one_mark, self.player_two_mark
             )
 
-    def valid_computer_move(self, move):
-        if not self.validator.spot_is_available(self.game_board, move):
-            return self.valid_computer_move(self.computer_player.computer_input())
-        return move
-
     def new_game(self):
         self.total_marks_on_board = 0
         self.game_board = Board().starter_board
-        self.player_one_mark = config["player_one_mark"]
-        self.player_two_mark = config["player_two_mark"]
+        self.player_one_mark = self.human_player.player_one_mark
+        self.player_two_mark = self.human_player.player_two_mark
 
     def get_winning_mark(self, total_marks_on_board):
         player = self.get_current_player(total_marks_on_board)

--- a/src/game.py
+++ b/src/game.py
@@ -112,7 +112,6 @@ class Game:
 
     def handle_mark_board(self, player, board):
         move = player.get_move(board, self.message.invalid_board_input())
-        # validate the move
         current_player = self.get_current_player(self.total_marks_on_board)
         if not self.rules.is_winner(self.game_board):
             self.game_board = self.board.mark_board(move, board, current_player.mark)

--- a/src/game.py
+++ b/src/game.py
@@ -111,7 +111,8 @@ class Game:
         self.ui.display_message(self.message.game_over_message())
 
     def handle_mark_board(self, player, board):
-        move = player.get_move(board)
+        move = player.get_move(board, self.message.invalid_board_input())
+        # validate the move
         current_player = self.get_current_player(self.total_marks_on_board)
         if not self.rules.is_winner(self.game_board):
             self.game_board = self.board.mark_board(move, board, current_player.mark)

--- a/src/game.py
+++ b/src/game.py
@@ -20,28 +20,13 @@ class Game:
         self.ui = ui
         self.set_language(message)
         self.game_board = self.board.starter_board
-        self.player_one = config["player_one"]
-        self.player_two = config["player_two"]
+        # self.player_one = config["player_one"]
+        # self.player_two = config["player_two"]
+        self.player_one_mark = config["player_one_mark"]
+        self.player_two_mark = config["player_two_mark"]
         self.total_marks_on_board = 0
         self.playing = True
         self.play_against_computer = False
-
-    def valid_computer_move(self, move):
-        if not self.validator.spot_is_available(self.game_board, move):
-            return self.valid_computer_move(self.computer_player.computer_input())
-        return move
-
-    def handle_computer_mark_board(self):
-        computer_move = self.computer_player.computer_input()
-        if not self.rules.is_winner(self.game_board):
-            self.game_board = self.board.mark_board(
-                self.valid_computer_move(computer_move),
-                self.game_board,
-                self.get_current_player(self.total_marks_on_board),
-            )
-            self.total_marks_on_board = self.board.count_marks(
-                self.game_board, self.player_one, self.player_two
-            )
 
     def set_language(self, message):
         self.message = message
@@ -79,10 +64,10 @@ class Game:
         )
         if user_input == config["play_with_symbols"]:
             self.ui.display_message(self.message.display_symbols())
-            self.player_one = self.set_player_symbol(
+            self.player_one_mark = self.set_player_symbol(
                 self.message.choose_symbol_player_one()
             )
-            self.player_two = self.set_player_symbol(
+            self.player_two_mark = self.set_player_symbol(
                 self.message.choose_symbol_player_two()
             )
 
@@ -101,9 +86,9 @@ class Game:
 
     def get_current_player(self, total_marks_on_board):
         if total_marks_on_board % 2 == 0:
-            return self.player_one
+            return self.player_one_mark
         else:
-            return self.player_two
+            return self.player_two_mark
 
     def prompt_for_move(self, total_marks_on_board):
         current_player = self.get_current_player(total_marks_on_board)
@@ -122,21 +107,38 @@ class Game:
             self.get_current_player(self.total_marks_on_board),
         )
         self.total_marks_on_board = self.board.count_marks(
-            self.game_board, self.player_one, self.player_two
+            self.game_board, self.player_one_mark, self.player_two_mark
         )
+
+    def handle_computer_mark_board(self):
+        computer_move = self.computer_player.computer_input()
+        if not self.rules.is_winner(self.game_board):
+            self.game_board = self.board.mark_board(
+                self.valid_computer_move(computer_move),
+                self.game_board,
+                self.get_current_player(self.total_marks_on_board),
+            )
+            self.total_marks_on_board = self.board.count_marks(
+                self.game_board, self.player_one_mark, self.player_two_mark
+            )
+
+    def valid_computer_move(self, move):
+        if not self.validator.spot_is_available(self.game_board, move):
+            return self.valid_computer_move(self.computer_player.computer_input())
+        return move
 
     def new_game(self):
         self.total_marks_on_board = 0
         self.game_board = Board().starter_board
-        self.player_one = config["player_one"]
-        self.player_two = config["player_two"]
+        self.player_one_mark = config["player_one_mark"]
+        self.player_two_mark = config["player_two_mark"]
 
     def get_winning_mark(self, total_marks_on_board):
         player = self.get_current_player(total_marks_on_board)
-        if player == self.player_one:
-            return self.player_two
+        if player == self.player_one_mark:
+            return self.player_two_mark
         else:
-            return self.player_one
+            return self.player_one_mark
 
     def handle_winning_game(self):
         winner = self.get_winning_mark(self.total_marks_on_board)
@@ -149,7 +151,7 @@ class Game:
         self.prompt_for_move(self.total_marks_on_board)
         self.handle_mark_board()
         self.total_marks_on_board = self.board.count_marks(
-            self.game_board, self.player_one, self.player_two
+            self.game_board, self.player_one_mark, self.player_two_mark
         )
         self.get_formatted_board()
 
@@ -159,7 +161,7 @@ class Game:
         self.ui.display_message(self.message.computer_took_turn())
         self.handle_computer_mark_board()
         self.total_marks_on_board = self.board.count_marks(
-            self.game_board, self.player_one, self.player_two
+            self.game_board, self.player_one_mark, self.player_two_mark
         )
         self.get_formatted_board()
 
@@ -193,7 +195,7 @@ class Game:
                 self.ask_to_play_again()
             elif self.board.is_full(
                 self.board.count_marks(
-                    self.game_board, self.player_one, self.player_two
+                    self.game_board, self.player_one_mark, self.player_two_mark
                 ),
                 self.game_board,
             ):

--- a/src/human_player.py
+++ b/src/human_player.py
@@ -1,0 +1,4 @@
+class HumanPlayer:
+    def __init__(self):
+        self.player_one_mark = "X"
+        self.player_two_mark = "O"

--- a/src/human_player.py
+++ b/src/human_player.py
@@ -7,9 +7,9 @@ class HumanPlayer:
     def __init__(self, mark):
         self.mark = mark
 
-    def get_move(self, board):
+    def get_move(self, board, message):
         move = UserInterface().get_user_input()
         if not Validator().is_valid_move(board, move):
-            UserInterface().display_message(Message().invalid_board_input())
-            return self.get_move(board)
+            UserInterface().display_message(message)
+            return self.get_move(board, message)
         return int(move)

--- a/src/human_player.py
+++ b/src/human_player.py
@@ -10,6 +10,6 @@ class HumanPlayer:
     def get_move(self, board, message):
         move = UserInterface().get_user_input()
         if not Validator().is_valid_move(board, move):
-            UserInterface().display_message(message)
+            UserInterface().display_message(message.invalid_board_input())
             return self.get_move(board, message)
         return int(move)

--- a/src/human_player.py
+++ b/src/human_player.py
@@ -1,4 +1,15 @@
+from src.user_interface import UserInterface
+from src.validator import Validator
+from src.message import Message
+
+
 class HumanPlayer:
-    def __init__(self):
-        self.player_one_mark = "X"
-        self.player_two_mark = "O"
+    def __init__(self, mark):
+        self.mark = mark
+
+    def get_move(self, board):
+        move = UserInterface().get_user_input()
+        if not Validator().is_valid_move(board, move):
+            UserInterface().display_message(Message().invalid_board_input())
+            return self.get_move(board)
+        return int(move)

--- a/src/message.py
+++ b/src/message.py
@@ -70,3 +70,10 @@ Choose your language:
 1. English
 2. Spanish
 """
+
+    def choose_players(self):
+        return """
+Please make a selection from the options:
+1. Human vs Human (2 players)
+2. Human vs Computer (1 player)
+"""

--- a/src/message.py
+++ b/src/message.py
@@ -77,6 +77,3 @@ Please make a selection from the options:
 1. Human vs Human (2 players)
 2. Human vs Computer (1 player)
 """
-
-    def computer_took_turn(self):
-        return "The computer player marked the board"

--- a/src/message.py
+++ b/src/message.py
@@ -47,7 +47,7 @@ At the end of every game, you will have the option to play again or to exit.
         return "Game over - it's a draw!"
 
     def prompt_for_move(self, current_player):
-        return f"Player {current_player} - enter a number to place your mark"
+        return f"Player {current_player.mark} - enter a number to place your mark"
 
     def declare_winner(self, winner):
         return f"Congrats Player {winner} - you are the winner!"

--- a/src/message.py
+++ b/src/message.py
@@ -77,3 +77,6 @@ Please make a selection from the options:
 1. Human vs Human (2 players)
 2. Human vs Computer (1 player)
 """
+
+    def computer_took_turn(self):
+        return "The computer player marked the board"

--- a/src/spanish_message.py
+++ b/src/spanish_message.py
@@ -44,7 +44,9 @@ Al final de cada juego, tendrás la opción de jugar de nuevo o salir.
         return "Se acabó el juego: ¡empate!"
 
     def prompt_for_move(self, current_player):
-        return f"Jugador {current_player} - escriba un número para marcar el tablero"
+        return (
+            f"Jugador {current_player.mark} - escriba un número para marcar el tablero"
+        )
 
     def declare_winner(self, winner):
         return f"Felicidades Jugador {winner} - ¡ganaste!"

--- a/src/spanish_message.py
+++ b/src/spanish_message.py
@@ -62,3 +62,10 @@ Al final de cada juego, tendrás la opción de jugar de nuevo o salir.
         return (
             "Esa elección es incorrecta. Ingrese Y para jugar de nuevo o N para salir."
         )
+
+    def choose_players(self):
+        return """
+Por favor, haga una selección de las opciones:
+1. Humano contra humano (2 jugadores)
+2. Humano contra computadora (1 jugador)
+"""

--- a/src/spanish_message.py
+++ b/src/spanish_message.py
@@ -69,3 +69,6 @@ Por favor, haga una selección de las opciones:
 1. Humano contra humano (2 jugadores)
 2. Humano contra computadora (1 jugador)
 """
+
+    def computer_took_turn(self):
+        return "La computadora marcó el tablero"

--- a/src/spanish_message.py
+++ b/src/spanish_message.py
@@ -71,6 +71,3 @@ Por favor, haga una selección de las opciones:
 1. Humano contra humano (2 jugadores)
 2. Humano contra computadora (1 jugador)
 """
-
-    def computer_took_turn(self):
-        return "La computadora marcó el tablero"

--- a/test/mocks/mock_message.py
+++ b/test/mocks/mock_message.py
@@ -50,3 +50,6 @@ class MockMessage:
 
     def choose_language(self):
         return "choose_language"
+
+    def choose_players(self):
+        return "choose_players"

--- a/test/mocks/mock_message.py
+++ b/test/mocks/mock_message.py
@@ -53,3 +53,6 @@ class MockMessage:
 
     def choose_players(self):
         return "choose_players"
+
+    def computer_took_turn(self):
+        return "computer_took_turn"

--- a/test/mocks/mock_message.py
+++ b/test/mocks/mock_message.py
@@ -31,7 +31,7 @@ class MockMessage:
         return "game_over_message"
 
     def prompt_for_move(self, current_player):
-        return f"prompt_for_move {current_player}"
+        return f"prompt_for_move {current_player.mark}"
 
     def declare_winner(self, winner):
         return f"declare_winner {winner}"

--- a/test/mocks/mock_message.py
+++ b/test/mocks/mock_message.py
@@ -53,6 +53,3 @@ class MockMessage:
 
     def choose_players(self):
         return "choose_players"
-
-    def computer_took_turn(self):
-        return "computer_took_turn"

--- a/test/test_acceptance_tests.py
+++ b/test/test_acceptance_tests.py
@@ -3,6 +3,7 @@ import sys
 import unittest
 from unittest.mock import patch
 from src.game import Game
+from src.spanish_message import SpanishMessage
 from test.mocks.mock_message import MockMessage
 
 
@@ -158,3 +159,14 @@ class TestAcceptance(unittest.TestCase):
     #     game_output = self.game_playthrough()
 
     #     self.assertIn(expected_message, game_output)
+
+    @patch(
+        "builtins.input",
+        side_effect=["2", "1", "1", "1", "2", "3", "4", "5", "6", "7", "n"],
+    )
+    def test_player_X_wins_the_game_in_spanish(self, mock_input):
+        expected_message = SpanishMessage.declare_winner(self, "X")
+
+        game_output = self.game_playthrough()
+
+        self.assertIn(expected_message, game_output)

--- a/test/test_acceptance_tests.py
+++ b/test/test_acceptance_tests.py
@@ -143,7 +143,7 @@ class TestAcceptance(unittest.TestCase):
     def test_invalid_inputs(self, mock_input):
         game_output = self.game_playthrough()
 
-        # self.assertIn(MockMessage.invalid_board_input(self), game_output)
+        self.assertIn(MockMessage.invalid_board_input(self), game_output)
         self.assertIn(MockMessage.invalid_menu_input(self), game_output)
         self.assertIn(MockMessage.invalid_repeat_game_input(self), game_output)
         self.assertIn(MockMessage.invalid_symbol_option(self), game_output)

--- a/test/test_acceptance_tests.py
+++ b/test/test_acceptance_tests.py
@@ -149,23 +149,23 @@ class TestAcceptance(unittest.TestCase):
         self.assertIn(MockMessage.invalid_repeat_game_input(self), game_output)
         self.assertIn(MockMessage.invalid_symbol_option(self), game_output)
 
-    # @patch(
-    #     "builtins.input",
-    #     side_effect=["1", "2", "1", "1", "2", "3", "4", "5", "6", "7", "n"],
-    # )
-    # def test_play_through_with_computer_player(self, mock_input):
-    #     expected_message = MockMessage.computer_took_turn(self)
-
-    #     game_output = self.game_playthrough()
-
-    #     self.assertIn(expected_message, game_output)
-
     @patch(
         "builtins.input",
         side_effect=["2", "1", "1", "1", "2", "3", "4", "5", "6", "7", "n"],
     )
     def test_player_X_wins_the_game_in_spanish(self, mock_input):
         expected_message = SpanishMessage.declare_winner(self, "X")
+
+        game_output = self.game_playthrough()
+
+        self.assertIn(expected_message, game_output)
+
+    @patch(
+        "builtins.input",
+        side_effect=["1", "2", "1", "1", "2", "3", "4", "5", "6", "7", "n"],
+    )
+    def test_play_through_with_computer_player(self, mock_input):
+        expected_message = MockMessage.goodbye_message(self)
 
         game_output = self.game_playthrough()
 

--- a/test/test_acceptance_tests.py
+++ b/test/test_acceptance_tests.py
@@ -147,3 +147,14 @@ class TestAcceptance(unittest.TestCase):
         self.assertIn(MockMessage.invalid_menu_input(self), game_output)
         self.assertIn(MockMessage.invalid_repeat_game_input(self), game_output)
         self.assertIn(MockMessage.invalid_symbol_option(self), game_output)
+
+    @patch(
+        "builtins.input",
+        side_effect=["1", "2", "1", "1", "2", "3", "4", "5", "6", "7", "n"],
+    )
+    def test_play_through_with_computer_player(self, mock_input):
+        expected_message = MockMessage.computer_took_turn(self)
+
+        game_output = self.game_playthrough()
+
+        self.assertIn(expected_message, game_output)

--- a/test/test_acceptance_tests.py
+++ b/test/test_acceptance_tests.py
@@ -143,18 +143,18 @@ class TestAcceptance(unittest.TestCase):
     def test_invalid_inputs(self, mock_input):
         game_output = self.game_playthrough()
 
-        self.assertIn(MockMessage.invalid_board_input(self), game_output)
+        # self.assertIn(MockMessage.invalid_board_input(self), game_output)
         self.assertIn(MockMessage.invalid_menu_input(self), game_output)
         self.assertIn(MockMessage.invalid_repeat_game_input(self), game_output)
         self.assertIn(MockMessage.invalid_symbol_option(self), game_output)
 
-    @patch(
-        "builtins.input",
-        side_effect=["1", "2", "1", "1", "2", "3", "4", "5", "6", "7", "n"],
-    )
-    def test_play_through_with_computer_player(self, mock_input):
-        expected_message = MockMessage.computer_took_turn(self)
+    # @patch(
+    #     "builtins.input",
+    #     side_effect=["1", "2", "1", "1", "2", "3", "4", "5", "6", "7", "n"],
+    # )
+    # def test_play_through_with_computer_player(self, mock_input):
+    #     expected_message = MockMessage.computer_took_turn(self)
 
-        game_output = self.game_playthrough()
+    #     game_output = self.game_playthrough()
 
-        self.assertIn(expected_message, game_output)
+    #     self.assertIn(expected_message, game_output)

--- a/test/test_acceptance_tests.py
+++ b/test/test_acceptance_tests.py
@@ -16,7 +16,8 @@ class TestAcceptance(unittest.TestCase):
         return captured_output.getvalue()
 
     @patch(
-        "builtins.input", side_effect=["1", "1", "1", "2", "3", "4", "5", "6", "7", "n"]
+        "builtins.input",
+        side_effect=["1", "1", "1", "1", "2", "3", "4", "5", "6", "7", "n"],
     )
     def test_player_X_wins_the_game(self, mock_input):
         expected_message = MockMessage.declare_winner(self, "X")
@@ -25,7 +26,9 @@ class TestAcceptance(unittest.TestCase):
 
         self.assertIn(expected_message, game_output)
 
-    @patch("builtins.input", side_effect=["1", "1", "1", "2", "3", "5", "4", "8", "n"])
+    @patch(
+        "builtins.input", side_effect=["1", "1", "1", "1", "2", "3", "5", "4", "8", "n"]
+    )
     def test_player_O_wins_the_game(self, mock_input):
         expected_message = MockMessage.declare_winner(self, "O")
 
@@ -35,7 +38,7 @@ class TestAcceptance(unittest.TestCase):
 
     @patch(
         "builtins.input",
-        side_effect=["1", "1", "1", "3", "2", "4", "5", "9", "6", "8", "7", "n"],
+        side_effect=["1", "1", "1", "1", "3", "2", "4", "5", "9", "6", "8", "7", "n"],
     )
     def test_play_through_ends_in_draw(self, mock_input):
         expected_message = MockMessage.game_over_message(self)
@@ -47,6 +50,7 @@ class TestAcceptance(unittest.TestCase):
     @patch(
         "builtins.input",
         side_effect=[
+            "1",
             "1",
             "1",
             "1",
@@ -78,7 +82,7 @@ class TestAcceptance(unittest.TestCase):
 
     @patch(
         "builtins.input",
-        side_effect=["1", "2", "1", "2", "1", "2", "3", "4", "5", "6", "7", "n"],
+        side_effect=["1", "1", "2", "1", "2", "1", "2", "3", "4", "5", "6", "7", "n"],
     )
     def test_player_one_wins_when_using_emojis(self, mock_input):
         expected_message = MockMessage.declare_winner(self, "😃")
@@ -89,7 +93,22 @@ class TestAcceptance(unittest.TestCase):
 
     @patch(
         "builtins.input",
-        side_effect=["1", "1", "1", "1", "2", "3", "4", "6", "7", "5", "8", "9", "n"],
+        side_effect=[
+            "1",
+            "1",
+            "1",
+            "1",
+            "1",
+            "2",
+            "3",
+            "4",
+            "6",
+            "7",
+            "5",
+            "8",
+            "9",
+            "n",
+        ],
     )
     def test_play_through_and_X_wins_when_board_is_full(self, mock_input):
         expected_message = MockMessage.declare_winner(self, "X")
@@ -101,6 +120,8 @@ class TestAcceptance(unittest.TestCase):
     @patch(
         "builtins.input",
         side_effect=[
+            "1",
+            "blah",
             "1",
             "blah",
             "2",

--- a/test/test_acceptance_tests.py
+++ b/test/test_acceptance_tests.py
@@ -159,14 +159,3 @@ class TestAcceptance(unittest.TestCase):
         game_output = self.game_playthrough()
 
         self.assertIn(expected_message, game_output)
-
-    @patch(
-        "builtins.input",
-        side_effect=["1", "2", "1", "1", "2", "3", "4", "5", "6", "7", "n"],
-    )
-    def test_play_through_with_computer_player(self, mock_input):
-        expected_message = MockMessage.goodbye_message(self)
-
-        game_output = self.game_playthrough()
-
-        self.assertIn(expected_message, game_output)

--- a/test/test_computer_player.py
+++ b/test/test_computer_player.py
@@ -10,3 +10,43 @@ class TestComputerPlayer(unittest.TestCase):
         result = comp_player.computer_input()
 
         self.assertIn(result, options)
+
+    def test_valid_computer_input_returns_true_when_spot_is_not_taken(self):
+        comp_player = ComputerPlayer()
+
+        game_board = ["1", "2", "3", "4", "5", "6", "7", "8", "9"]
+        move = 1
+
+        result = comp_player.valid_computer_move(move, game_board)
+
+        self.assertEqual(True, result)
+
+    def test_valid_computer_input_returns_false_when_spot_is_taken(self):
+        comp_player = ComputerPlayer()
+
+        game_board = ["X", "2", "3", "4", "5", "6", "7", "8", "9"]
+        move = 1
+
+        result = comp_player.valid_computer_move(move, game_board)
+
+        self.assertEqual(False, result)
+
+    def test_get_computer_move_does_not_mark_board_if_spot_is_taken(self):
+        comp_player = ComputerPlayer()
+
+        game_board = ["X", "2", "3", "4", "5", "6", "7", "8", "9"]
+        move = 1
+
+        result = comp_player.get_computer_move(move, game_board)
+
+        self.assertNotEqual(1, result)
+
+    def test_get_computer_move_returns_valid_move(self):
+        comp_player = ComputerPlayer()
+
+        game_board = ["1", "2", "3", "4", "5", "6", "7", "8", "9"]
+        move = 1
+
+        result = comp_player.get_computer_move(move, game_board)
+
+        self.assertEqual(1, result)

--- a/test/test_computer_player.py
+++ b/test/test_computer_player.py
@@ -3,50 +3,13 @@ from src.computer_player import ComputerPlayer
 
 
 class TestComputerPlayer(unittest.TestCase):
-    def test_computer_input_returns_random_str_int_bn_1_and_9(self):
-        comp_player = ComputerPlayer()
-        options = [1, 2, 3, 4, 5, 6, 7, 8, 9]
+    def test_get_move_returns_valid_move(self):
+        comp_player = ComputerPlayer("X")
 
-        result = comp_player.computer_input()
+        game_board = ["X", "X", "X", "X", "5", "X", "X", "X", "X"]
 
-        self.assertIn(result, options)
+        result = comp_player.get_move(game_board)
 
-    def test_valid_computer_input_returns_true_when_spot_is_not_taken(self):
-        comp_player = ComputerPlayer()
+        self.assertEqual(5, result)
 
-        game_board = ["1", "2", "3", "4", "5", "6", "7", "8", "9"]
-        move = 1
 
-        result = comp_player.valid_computer_move(move, game_board)
-
-        self.assertEqual(True, result)
-
-    def test_valid_computer_input_returns_false_when_spot_is_taken(self):
-        comp_player = ComputerPlayer()
-
-        game_board = ["X", "2", "3", "4", "5", "6", "7", "8", "9"]
-        move = 1
-
-        result = comp_player.valid_computer_move(move, game_board)
-
-        self.assertEqual(False, result)
-
-    def test_get_computer_move_does_not_mark_board_if_spot_is_taken(self):
-        comp_player = ComputerPlayer()
-
-        game_board = ["X", "2", "3", "4", "5", "6", "7", "8", "9"]
-        move = 1
-
-        result = comp_player.get_computer_move(move, game_board)
-
-        self.assertNotEqual(1, result)
-
-    def test_get_computer_move_returns_valid_move(self):
-        comp_player = ComputerPlayer()
-
-        game_board = ["1", "2", "3", "4", "5", "6", "7", "8", "9"]
-        move = 1
-
-        result = comp_player.get_computer_move(move, game_board)
-
-        self.assertEqual(1, result)

--- a/test/test_computer_player.py
+++ b/test/test_computer_player.py
@@ -1,0 +1,12 @@
+import unittest
+from src.computer_player import ComputerPlayer
+
+
+class TestComputerPlayer(unittest.TestCase):
+    def test_computer_input_returns_random_str_int_bn_1_and_9(self):
+        comp_player = ComputerPlayer()
+        options = [1, 2, 3, 4, 5, 6, 7, 8, 9]
+
+        result = comp_player.computer_input()
+
+        self.assertIn(result, options)

--- a/test/test_computer_player.py
+++ b/test/test_computer_player.py
@@ -7,9 +7,8 @@ class TestComputerPlayer(unittest.TestCase):
         comp_player = ComputerPlayer("X")
 
         game_board = ["X", "X", "X", "X", "5", "X", "X", "X", "X"]
+        message = "message"
 
-        result = comp_player.get_move(game_board)
+        result = comp_player.get_move(game_board, message)
 
         self.assertEqual(5, result)
-
-

--- a/test/test_game.py
+++ b/test/test_game.py
@@ -106,3 +106,11 @@ class TestGame(unittest.TestCase):
         result = game.set_player_symbol(message)
 
         self.assertEqual(expected_symbol, result)
+
+    def test_computer_input_returns_random_str_int_bn_1_and_9(self):
+        game = Game()
+        options = [1, 2, 3, 4, 5, 6, 7, 8, 9]
+
+        result = game.computer_input()
+
+        self.assertIn(result, options)

--- a/test/test_game.py
+++ b/test/test_game.py
@@ -2,6 +2,7 @@ import unittest
 from unittest.mock import patch
 
 from src.game import Game
+from src.human_player import HumanPlayer
 from src.symbol import SymbolOptions
 from test.mocks.mock_message import MockMessage
 
@@ -10,26 +11,29 @@ class TestGame(unittest.TestCase):
     @patch("builtins.print")
     def test_prompt_x_for_first_turn(self, mock_print):
         message = MockMessage()
+        test_player = HumanPlayer("X")
         game = Game(message=message)
         total_marks_on_board = 0
         game.prompt_for_move(total_marks_on_board)
-        mock_print.assert_called_with(message.prompt_for_move("X"))
+        mock_print.assert_called_with(message.prompt_for_move(test_player))
 
     @patch("builtins.print")
     def test_prompt_o_for_second_turn(self, mock_print):
         message = MockMessage()
+        test_player = HumanPlayer("O")
         game = Game(message=message)
         total_marks_on_board = 1
         game.prompt_for_move(total_marks_on_board)
-        mock_print.assert_called_with(message.prompt_for_move("O"))
+        mock_print.assert_called_with(message.prompt_for_move(test_player))
 
     @patch("builtins.print")
     def test_prompt_x_for_third_turn(self, mock_print):
         message = MockMessage()
+        test_player = HumanPlayer("X")
         game = Game(message=message)
         total_marks_on_board = 2
         game.prompt_for_move(total_marks_on_board)
-        mock_print.assert_called_with(message.prompt_for_move("X"))
+        mock_print.assert_called_with(message.prompt_for_move(test_player))
 
     @patch("builtins.print")
     def test_handle_draw_displays_game_over_message(self, mock_print):
@@ -42,19 +46,19 @@ class TestGame(unittest.TestCase):
         game = Game()
         total_marks_on_board = 0
         current_player = game.get_current_player(total_marks_on_board)
-        self.assertEqual("X", current_player)
+        self.assertEqual("X", current_player.mark)
 
     def test_one_turn_player_o_goes_next(self):
         game = Game()
         total_marks_on_board = 1
         current_player = game.get_current_player(total_marks_on_board)
-        self.assertEqual("O", current_player)
+        self.assertEqual("O", current_player.mark)
 
     def test_two_turn_player_x_goes_next(self):
         game = Game()
         total_marks_on_board = 2
         current_player = game.get_current_player(total_marks_on_board)
-        self.assertEqual("X", current_player)
+        self.assertEqual("X", current_player.mark)
 
     def test_if_current_player_is_O_then_X_wins(self):
         game = Game()

--- a/test/test_game.py
+++ b/test/test_game.py
@@ -1,10 +1,12 @@
 import unittest
 from unittest.mock import patch
+from src.computer_player import ComputerPlayer
 
 from src.game import Game
 from src.human_player import HumanPlayer
 from src.symbol import SymbolOptions
 from test.mocks.mock_message import MockMessage
+from src.board import Board
 
 
 class TestGame(unittest.TestCase):
@@ -110,3 +112,12 @@ class TestGame(unittest.TestCase):
         result = game.set_player_symbol(message)
 
         self.assertEqual(expected_symbol, result)
+
+    def test_board_is_marked_by_computer_player(self):
+        test_player = ComputerPlayer("X")
+        game = Game()
+        board = Board()
+        game_board = ["X", "2", "3", "4", "5", "6", "7", "8", "9"]
+        game.handle_mark_board(test_player, game_board)
+        marks_on_board = board.count_marks(game_board, "X", "O")
+        self.assertEqual(marks_on_board, 2)

--- a/test/test_game.py
+++ b/test/test_game.py
@@ -106,11 +106,3 @@ class TestGame(unittest.TestCase):
         result = game.set_player_symbol(message)
 
         self.assertEqual(expected_symbol, result)
-
-    def test_computer_input_returns_random_str_int_bn_1_and_9(self):
-        game = Game()
-        options = [1, 2, 3, 4, 5, 6, 7, 8, 9]
-
-        result = game.computer_input()
-
-        self.assertIn(result, options)

--- a/test/test_human_player.py
+++ b/test/test_human_player.py
@@ -8,7 +8,8 @@ class TestHumanPlayer(unittest.TestCase):
     def test_get_move_returns_valid_user_move(self, mock_input):
         human_player = HumanPlayer("X")
         game_board = ["1", "2", "3", "4", "5", "6", "7", "8", "9"]
+        message = "invalid_board_input"
 
-        result = human_player.get_move(game_board)
+        result = human_player.get_move(game_board, message)
 
         self.assertEqual(1, result)

--- a/test/test_human_player.py
+++ b/test/test_human_player.py
@@ -1,0 +1,14 @@
+import unittest
+from unittest.mock import patch
+from src.human_player import HumanPlayer
+
+
+class TestHumanPlayer(unittest.TestCase):
+    @patch("builtins.input", side_effect=["1"])
+    def test_get_move_returns_valid_user_move(self, mock_input):
+        human_player = HumanPlayer("X")
+        game_board = ["1", "2", "3", "4", "5", "6", "7", "8", "9"]
+
+        result = human_player.get_move(game_board)
+
+        self.assertEqual(1, result)

--- a/test/test_message.py
+++ b/test/test_message.py
@@ -134,9 +134,3 @@ Please make a selection from the options:
 """
         actual_message = message.choose_players()
         self.assertEqual(expected_message, actual_message)
-
-    def test_computer_took_turn_prints_to_console(self):
-        message = Message()
-        expected_message = "The computer player marked the board"
-        actual_message = message.computer_took_turn()
-        self.assertEqual(expected_message, actual_message)

--- a/test/test_message.py
+++ b/test/test_message.py
@@ -135,3 +135,9 @@ Please make a selection from the options:
 """
         actual_message = message.choose_players()
         self.assertEqual(expected_message, actual_message)
+
+    def test_computer_took_turn_prints_to_console(self):
+        message = Message()
+        expected_message = "The computer player marked the board"
+        actual_message = message.computer_took_turn()
+        self.assertEqual(expected_message, actual_message)

--- a/test/test_message.py
+++ b/test/test_message.py
@@ -125,3 +125,13 @@ Choose your language:
 """
         actual_message = message.choose_language()
         self.assertEqual(expected_message, actual_message)
+
+    def test_choose_players_prints_to_console(self):
+        message = Message()
+        expected_message = """
+Please make a selection from the options:
+1. Human vs Human (2 players)
+2. Human vs Computer (1 player)
+"""
+        actual_message = message.choose_players()
+        self.assertEqual(expected_message, actual_message)

--- a/test/test_message.py
+++ b/test/test_message.py
@@ -1,4 +1,5 @@
 import unittest
+from src.human_player import HumanPlayer
 
 from src.message import Message
 from src.symbol import SymbolOptions
@@ -64,11 +65,9 @@ Choose one of the options below:
 
     def test_X_player_is_prompted_for_move_when_is_current_player(self):
         message = Message()
-        current_player = "X"
-        expected_message = (
-            f"Player {current_player} - enter a number to place your mark"
-        )
-        actual_message = message.prompt_for_move(current_player)
+        player = HumanPlayer("X")
+        expected_message = f"Player {player.mark} - enter a number to place your mark"
+        actual_message = message.prompt_for_move(player)
         self.assertEqual(expected_message, actual_message)
 
     def test_declare_winner_with_correct_mark_as_winner(self):

--- a/test/test_spanish_message.py
+++ b/test/test_spanish_message.py
@@ -125,3 +125,9 @@ Por favor, haga una selección de las opciones:
 """
         actual_message = spanish_message.choose_players()
         self.assertEqual(expected_message, actual_message)
+
+    def test_computer_took_turn_prints_to_console(self):
+        spanish_message = SpanishMessage()
+        expected_message = "La computadora marcó el tablero"
+        actual_message = spanish_message.computer_took_turn()
+        self.assertEqual(expected_message, actual_message)

--- a/test/test_spanish_message.py
+++ b/test/test_spanish_message.py
@@ -115,3 +115,13 @@ Al final de cada juego, tendrás la opción de jugar de nuevo o salir.
 """
         actual_message = spanish_message.rules()
         self.assertEqual(rules, actual_message)
+
+    def test_choose_players_prints_to_console(self):
+        spanish_message = SpanishMessage()
+        expected_message = """
+Por favor, haga una selección de las opciones:
+1. Humano contra humano (2 jugadores)
+2. Humano contra computadora (1 jugador)
+"""
+        actual_message = spanish_message.choose_players()
+        self.assertEqual(expected_message, actual_message)

--- a/test/test_spanish_message.py
+++ b/test/test_spanish_message.py
@@ -2,6 +2,7 @@ import unittest
 
 from src.spanish_message import SpanishMessage
 from src.symbol import SymbolOptions
+from src.human_player import HumanPlayer
 
 
 class TestSpanishMessage(unittest.TestCase):
@@ -63,11 +64,11 @@ Elija una de las siguientes opciones:
 
     def test_X_player_is_prompted_for_move_when_is_current_player(self):
         spanish_message = SpanishMessage()
-        current_player = "X"
+        player = HumanPlayer("X")
         expected_message = (
-            f"Jugador {current_player} - escriba un número para marcar el tablero"
+            f"Jugador {player.mark} - escriba un número para marcar el tablero"
         )
-        actual_message = spanish_message.prompt_for_move(current_player)
+        actual_message = spanish_message.prompt_for_move(player)
         self.assertEqual(expected_message, actual_message)
 
     def test_declare_winner_with_correct_mark_as_winner(self):

--- a/test/test_spanish_message.py
+++ b/test/test_spanish_message.py
@@ -126,9 +126,3 @@ Por favor, haga una selección de las opciones:
 """
         actual_message = spanish_message.choose_players()
         self.assertEqual(expected_message, actual_message)
-
-    def test_computer_took_turn_prints_to_console(self):
-        spanish_message = SpanishMessage()
-        expected_message = "La computadora marcó el tablero"
-        actual_message = spanish_message.computer_took_turn()
-        self.assertEqual(expected_message, actual_message)


### PR DESCRIPTION
Trello ticket: https://trello.com/c/93qR2hmV/44-simple-computer-player

Added in or added to:
- `ComputerPlayer` class
- validate `computer_player` move
- `computer_player` marks board
- method for `take_turns` when computer player vs human players
- Menu to choose between human vs human and human vs computer (will prompt after each game)
- Updated acceptance tests with input for new computer player menu

Not yet implemented:
- Right now, the human has to choose both symbols (if they are not playing with X and O), even when they choose human vs computer

Considerations:
- The human player always goes first in this version - is that what we want?
- Do I want to include messaging that's different if the computer wins (instead of just saying, "Player O, you're the winner" - something like, "Aw man, you lost to the computer!")